### PR TITLE
What's Next support in front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ mimic the page hierarchy in ReadMe.
 The local Markdown content files act as the database of pages and their contents. To support "storing" more than the
 actual Markdown content, additional metadata about each page is specified in [YAML front matter](https://jekyllrb.com/docs/front-matter/).
 
-Example:
+Full example:
 
     ---
-    title: "Welcome"
-    excerpt: "This is the entry point of our documentation"
+    title: Welcome
+    excerpt: This is the entry point of our documentation
+    hidden: 'true'
+    next:
+      pages: 
+        - other-page-slug1
+        - other-page-slug2
+      description: Text to be shown in the What's Next box
     ---
     # This is the page header
     
@@ -39,11 +45,14 @@ Example:
 
 The following YAML attributes are supported:
 
-| Attribute | Description                                                                                        |
-| ---       | ---                                                                                                |
-| `title`   | The page title.                                                                                    |
-| `excerpt` | The small summary that appears under the page title in ReadMe.                                     |
-| `hidden`  | (Optional) If set to `true`, then the page will be hidden / un-published in the ReadMe navigation. |
+| Attribute          | Description                                                                                        |
+| ---                | ---                                                                                                |
+| `title`            | The page title.                                                                                    |
+| `excerpt`          | The small summary that appears under the page title in ReadMe.                                     |
+| `hidden`           | (Optional) If set to `true`, then the page will be hidden / un-published in the ReadMe navigation. |
+| `next`             | (Optional) Allows control on the *What's Next* entries displayed by ReadMe.                        |
+| `next.pages`       | (Optional) List of page slugs that should be referenced in the *What's Next* section.              |
+| `next.description` | (Optional) Text to be displayed as introduction in the *What's Next* section.                      |
 
 ## Using the `readme-sync` CLI in your project
 

--- a/bin/readme.js
+++ b/bin/readme.js
@@ -201,6 +201,7 @@ The following validators are available:
  - 'mailtos':      Verifies that mailto: links (links to email addresses) are correctly formed.
  - 'headings':     Verifies that section headings are at minimum 2 levels deep
  - 'images':       Verifies that images (either specified with a relative path or with a remote URL) do exist.
+ - 'whatsnext':    Verifies that pages references listed in 'next' front matter point to known content pages.
 
 All validations are performed unless --validations is specified.
     `)

--- a/bin/readme.js
+++ b/bin/readme.js
@@ -116,15 +116,15 @@ program
             prune: cmd.prune,
         };
 
-        let catalog = Catalog.build(cmd.dir);
+        const fullCatalog = Catalog.build(cmd.dir);
+        const readme = apiClient(fullCatalog, options);
 
-        catalog = await selectPages(catalog, options);
+        const catalog = await selectPages(fullCatalog, options);
         if (catalog.length === 0) {
             console.warn('No files to found to push.');
             return;
         }
 
-        const readme = apiClient(catalog, options);
         for (let page of catalog.pages) {
             for (const filter of createFilters(options.config)) {
                 page = await filter.apply(page);

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -173,7 +173,16 @@ class Api {
             title: json.title,
             excerpt: json.excerpt,
             hidden: json.hidden,
+            next: undefined,
         };
+
+        if (json.next.pages.length > 0) {
+            headers.next = {
+                pages: json.next.pages.map(page => page.slug),
+                description: json.next.description
+            };
+        }
+
         return new Page(category, parent ? parent.slug : null, json.slug, json.body, headers);
     }
 }

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -109,8 +109,7 @@ class Api {
                 .put(`${API_ROOT}/docs/${localPage.slug}`, {
                     ...this.httpOptions,
                     json: Object.assign(pageJson, {
-                        ...localPage.headers,
-                        body: localPage.content,
+                        ...this.pageToJson(localPage),
                         lastUpdatedHash: localPage.hash,
                     }),
                 });
@@ -128,13 +127,11 @@ class Api {
         }
 
         let postJson = {
-            ...localPage.headers,
+            ...this.pageToJson(localPage),
             category: category._id,
             parentDoc: parentPage ? parentPage._id : null,
             slug: localPage.slug,
-            body: localPage.content,
             lastUpdatedHash: localPage.hash,
-            hidden: false,
         };
 
         if (this.options.dryRun) {
@@ -184,6 +181,43 @@ class Api {
         }
 
         return new Page(category, parent ? parent.slug : null, json.slug, json.body, headers);
+    }
+
+    /**
+     * Converts a `Page` object instance to JSON that ReadMe accepts as inputs for page modifications.
+     * @param page The local page to represent for the ReadMe API.
+     */
+    pageToJson(page) {
+        const json = {
+            title: page.title,
+            excerpt: page.excerpt,
+            hidden: page.hidden,
+            body: page.content,
+            next: {
+                pages: [],
+                description: ''
+            }
+        };
+
+        if (page.headers.next) {
+            json.next = Object.assign(json.next, page.headers.next);
+            if (json.next.pages) {
+                // resolve each referenced page in local catalog and derive data
+                json.next.pages = json.next.pages
+                    .map(slug => this.catalog.find(Page.bySlug(slug)))
+                    .filter(page => page !== undefined)
+                    .map(resolvedPage => {
+                        return {
+                            slug: resolvedPage.slug,
+                            name: resolvedPage.title,
+                            icon: 'file-text-o',
+                            type: 'doc'
+                        }
+                    })
+            }
+        }
+
+        return json;
     }
 }
 

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -164,6 +164,7 @@ class Page {
             this.title,
             this.excerpt,
             this.hidden,
+            this.headers.next,
             content
         ].join('\n');
     }
@@ -175,6 +176,15 @@ class Page {
         };
         if (this.hidden) {
             frontMatter['hidden'] = 'true';
+        }
+        if (this.headers.next) {
+            const next = frontMatter['next'] = {};
+            if (this.headers.next.pages.length > 0) {
+                next['pages'] = this.headers.next.pages;
+            }
+            if (this.headers.next.description) {
+                next['description'] = this.headers.next.description;
+            }
         }
 
         return `---\n${yaml.safeDump(frontMatter)}---\n${this.content}`;

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -150,7 +150,6 @@ class Page {
 
     /**
      * Actual data that is used to compute content hash identity
-     * Because the page ID changes between Readme versions, we're leaving it out from the hash computation
      */
     get hashData() {
         // readme.io always strips the last newline from content, so do the same here to prevent unnecessary content
@@ -160,13 +159,13 @@ class Page {
             content = content.substr(0, this.content.length - 1);
         }
 
-        return [
-            this.title,
-            this.excerpt,
-            this.hidden,
-            this.headers.next,
-            content
-        ].join('\n');
+        return JSON.stringify({
+            title: this.title,
+            excerpt: this.excerpt,
+            hidden: this.hidden,
+            next: this.headers.next,
+            content: content
+        });
     }
 
     get sources() {
@@ -179,7 +178,7 @@ class Page {
         }
         if (this.headers.next) {
             const next = frontMatter['next'] = {};
-            if (this.headers.next.pages.length > 0) {
+            if (this.headers.next.pages) {
                 next['pages'] = this.headers.next.pages;
             }
             if (this.headers.next.description) {

--- a/src/validators.js
+++ b/src/validators.js
@@ -157,6 +157,26 @@ class HeadingsValidator extends Validator {
     }
 }
 
+class WhatsNextValidator extends Validator {
+
+    async validate(catalog, page, options, errorCallback) {
+        const next = page.headers.next;
+        if (next && next.pages) {
+            for (const slug of next.pages) {
+                if (catalog.find(Page.bySlug(slug)) === undefined) {
+                    const element = {
+                        ref: page.ref,
+                        desc: slug
+                    };
+                    errorCallback(element,
+                        'Invalid page reference in `next.pages` front matter entry. ' +
+                        'A page with this slug could not be found in local catalog.');
+                }
+            }
+        }
+    }
+}
+
 
 module.exports = {
     xrefs: new XrefLinkValidator(),
@@ -164,5 +184,6 @@ module.exports = {
     mailtos: new MailtoLinkValidator(),
     images: new HrefValidator(link => link instanceof Image),
     headings: new HeadingsValidator(),
+    whatsnext: new WhatsNextValidator(),
 };
 


### PR DESCRIPTION
The *What's Next* section on pages is now populated from data in the `next` front matter entry for each page. Only page slugs should be listed under `next.pages`:

``` yaml
    ---
    title: Welcome
    excerpt: This is the entry point of our documentation
    hidden: 'true'
    next:
      pages: 
        - other-page-slug1
        - other-page-slug2
      description: Text to be shown in the What's Next box
    ---
```

ReadMe allows to display any text for each What's Next entry but I've figured it would be easier to maintain if we derived the text from the referenced page's title. 

Front matter is also now populated when fetching updated contents from the ReadMe API.

And finally, a validator has been added to make sure any page slug referenced does refer to an existing page in the local catalog. 

Addresses feature #2 