### PR TITLE
support for 'order' field

### DIFF
--- a/src/api-client.js
+++ b/src/api-client.js
@@ -195,6 +195,7 @@ class Api {
     const headers = {
       title: json.title,
       excerpt: json.excerpt,
+      order: json.order,
       hidden: json.hidden,
       next: undefined,
     };
@@ -223,6 +224,7 @@ class Api {
     const json = {
       title: page.title,
       excerpt: page.excerpt,
+      order: page.order,
       hidden: page.hidden,
       body: page.content,
       next: {

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -125,6 +125,10 @@ class Page {
     return this.headers.excerpt;
   }
 
+  get order() {
+    return this.headers.order;
+  }
+
   get hidden() {
     return this.headers.hidden === undefined ? false : this.headers.hidden;
   }
@@ -164,6 +168,7 @@ class Page {
     var data = JSON.stringify({
       title: this.title.replace(/(\r\n|\n|\r)/gm, "").replace(/ /g, ""),
       excerpt: this.excerpt.replace(/(\r\n|\n|\r)/gm, "").replace(/ /g, ""),
+      order: this.order,
       hidden: this.hidden,
       next: this.headers.next,
       content: tempcontent,


### PR DESCRIPTION
Hello, thanks for this great tool.

This PR adds support for the 'order' field, which allows specifying an order for the pages into readme.

Example:
```markdown
---
title: example
excerpt: ''
order: 10
---
# my title
...
```